### PR TITLE
Tweak giphy script to select first result, not a random result 

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,6 +1,6 @@
 [
   "redis-brain.coffee", "shipit.coffee",
   "points.coffee", "swanson.coffee",
-  "location-decision-maker.coffee", "giphy.coffee", "remind.coffee",
+  "location-decision-maker.coffee", "remind.coffee",
   "keep-alive.coffee", "ambush.coffee"
 ]

--- a/scripts/giphy.coffee
+++ b/scripts/giphy.coffee
@@ -1,0 +1,43 @@
+# NOTE: forked from https://github.com/github/hubot-scripts/blob/master/src/scripts/giphy.coffee
+# Changed from returning a random result to returning the first result
+#
+# Description:
+#   A way to search images on giphy.com
+#
+# Configuration:
+#   HUBOT_GIPHY_API_KEY
+#
+# Commands:
+#   hubot gif me <query> - Returns an animated gif matching the requested search term.
+
+giphy =
+  api_key: process.env.HUBOT_GIPHY_API_KEY
+  base_url: 'http://api.giphy.com/v1'
+
+module.exports = (robot) ->
+  robot.respond /(gif|giphy)( me)? (.*)/i, (msg) ->
+    giphyMe msg, msg.match[3], (url) ->
+      msg.send url
+
+giphyMe = (msg, query, cb) ->
+  endpoint = '/gifs/search'
+  url = "#{giphy.base_url}#{endpoint}"
+
+  msg.http(url)
+    .query
+      q: query
+      api_key: giphy.api_key
+    .get() (err, res, body) ->
+      response = undefined
+      try
+        response = JSON.parse(body)
+        images = response.data
+        if images.length > 0
+          image = images[0]
+          cb image.images.original.url
+
+      catch e
+        response = undefined
+        cb 'Error'
+
+      return if response is undefined


### PR DESCRIPTION
Sometimes it's fun that bort picks a random gif result, but most of the time we're probably better served with the first result. Let's try that for awhile?
